### PR TITLE
本番で絵文字を保存できないのを修正

### DIFF
--- a/advanced-sns-api/.env.production
+++ b/advanced-sns-api/.env.production
@@ -15,5 +15,5 @@ TYPEORM_DATABASE=__SECRET_TYPEORM_DATABASE__
 TYPEORM_ENTITIES="dist/src/**/*.entity.js"
 TYPEORM_MIGRATIONS="dist/src/migration/**/*.js"
 TYPEORM_SUBSCRIBERS="dist/src/subscriber/**/*.js"
-TYPEORM_DRIVER_EXTRA='{"socketPath": __SECRET_TYPEORM_HOST__}'
+TYPEORM_DRIVER_EXTRA='{"charset": "utf8mb4", "socketPath": __SECRET_TYPEORM_HOST__}'
 TYPEORM_MIGRATIONS_RUN="0"


### PR DESCRIPTION
本番でDB Clientのcharsetがセットされてなかったのが問題。
本当は本番も ormconfig.js を参照するように直したほうがいいと思うが、取り急ぎ修正。